### PR TITLE
From master wnewjec

### DIFF
--- a/python/postprocessing/modules/jme/jetSmearer.py
+++ b/python/postprocessing/modules/jme/jetSmearer.py
@@ -33,16 +33,6 @@ class jetSmearer(Module):
         # (needed for jet pT smearing)
         self.rnd = ROOT.TRandom3(12345)
 
-        # intialize smearing systematics (that depend on era)
-        # To do : change to real values
-        self.jmrVals = [0.1, 0.2, 0.0]
-        if '2016' in globalTag and jetType == "AK8PFPuppi":
-        #taken from https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#2016_scale_factors_and_correctio
-            self.jmrVals = [1.00, 0.8 , 1.2]
-        else:
-        # To do : change to real values
-            self.jmrVals = [0.1, 0.2, 0.0]
-
         # load libraries for accessing JER scale factors and uncertainties from txt files
         for library in [ "libCondFormatsJetMETObjects", "libPhysicsToolsNanoAODTools" ]:
             if library not in ROOT.gSystem.GetLibraries():
@@ -176,7 +166,7 @@ class jetSmearer(Module):
         enum_shift_down      = 1
         #--------------------------------------------------------------------------------------------
 
-        jet_m_sf_and_uncertainty = dict( zip( [enum_nominal, enum_shift_up, enum_shift_down],  self.jmrVals) )
+        jet_m_sf_and_uncertainty = dict( zip( [enum_nominal, enum_shift_up, enum_shift_down],  jmrVals) )
 
         # generate random number with flat distribution between 0 and 1
         u = self.rnd.Rndm()

--- a/python/postprocessing/modules/jme/jetSmearer.py
+++ b/python/postprocessing/modules/jme/jetSmearer.py
@@ -28,6 +28,16 @@ class jetSmearer(Module):
         # (needed for jet pT smearing)
         self.rnd = ROOT.TRandom3(12345)
 
+        # intialize smearing systematics (that depend on era)
+        # To do : change to real values
+        self.jmrVals = [0.1, 0.2, 0.0]
+        if '2016' in globalTag and jetType == "AK8PFPuppi":
+        #taken from https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#2016_scale_factors_and_correctio
+            self.jmrVals = [1.00, 0.8 , 1.2]
+        else:
+        # To do : change to real values
+            self.jmrVals = [0.1, 0.2, 0.0]
+
         # load libraries for accessing JER scale factors and uncertainties from txt files
         for library in [ "libCondFormatsJetMETObjects", "libPhysicsToolsNanoAODTools" ]:
             if library not in ROOT.gSystem.GetLibraries():
@@ -127,7 +137,7 @@ class jetSmearer(Module):
     
 
 
-    def getSmearValsM(self, jetIn, genJetIn ):
+    def getSmearValsM(self, jetIn, genJetIn, jmrVals = None):
         if hasattr( jetIn, "p4"):
             jet = jetIn.p4()
         else :
@@ -137,7 +147,9 @@ class jetSmearer(Module):
         else :
             genJet = genJetIn
 
-        
+        if not jmrVals:
+            jmrVals = [0.1, 0.2, 0.0]
+
         #--------------------------------------------------------------------------------------------
         # CV: Smear jet m to account for measured difference in JER between data and simulation.
         #     The function computes the nominal smeared jet m simultaneously with the JER up and down shifts,
@@ -159,7 +171,7 @@ class jetSmearer(Module):
         enum_shift_down      = 1
         #--------------------------------------------------------------------------------------------
 
-        jet_m_sf_and_uncertainty = dict( zip( [enum_nominal, enum_shift_up, enum_shift_down], [0.1, 0.2, 0.0] ) )
+        jet_m_sf_and_uncertainty = dict( zip( [enum_nominal, enum_shift_up, enum_shift_down],  self.jmrVals) )
 
         # generate random number with flat distribution between 0 and 1
         u = self.rnd.Rndm()

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -57,13 +57,30 @@ class jetmetUncertaintiesProducer(Module):
         self.jmsVals = [1.00, 0.99, 1.01]
         # Scale for m_softdrop
         self.jmsSDVals = [1.00, 1.00, 1.00]
+        self.jmrSDVals = [1.00, 1.00, 1.00]
+        # Scale for m_softdrop in tau21_DDT < 0.43 region
+        self.jmsSDVals_tau21DDT = [1.00, 1.00, 1.00]
+        self.jmrSDVals_tau21DDT = [1.00, 1.00, 1.00]
         if era == '2016':
+            # jms
             self.jmsSDVals = [1.00, 0.9906, 1.0094]
-            #self.jmrSDVals = [1.00, 0.8 , 1.2]
+            self.jmsSDVals_tau21DDT = [1.014, 1.007, 1.021]
+            # jmr
+            self.jmrSDVals = [1.00, 0.8 , 1.2]
+            self.jmrSDVals_tau21DDT = [1.086, 0.996, 1.176]
+        if era ==  '2017':
+            self.jmsSDVals = [0.983, 0.976, 0.99]
+            self.jmsSDVals_tau21DDT = [0.983, 0.976, 0.99]
+            # jmr
+            self.jmrSDVals = [1.080, 0.999, 1.161]
+            self.jmrSDVals_tau21DDT = [1.080, 0.999, 1.161]
+
         else:
         # To do : change to real values
             self.jmsSDVals = [1.00, 0.99, 1.01]
-            #self.jmrSDVals = [0.1, 0.2, 0.0]
+            self.jmsSDVals_tau21DDT = [1.00, 0.99, 1.01]
+            self.jmrSDVals = [0.1, 0.2, 0.0]
+            self.jmrSDVals_tau21DDT = [0.1, 0.2, 0.0]
         
 
         # read jet energy scale (JES) uncertainties
@@ -101,7 +118,6 @@ class jetmetUncertaintiesProducer(Module):
                 sources = filter(lambda x: x.startswith("[") and x.endswith("]"), lines)
                 sources = map(lambda x: x[1:-1], sources)
                 self.jesUncertainties = sources
-            
 
         if self.redoJEC :
             self.jetReCalibrator = JetReCalibrator(globalTag, jetType , True, self.jesInputFilePath, calculateSeparateCorrections = False, calculateType1METCorrection  = False)
@@ -144,6 +160,7 @@ class jetmetUncertaintiesProducer(Module):
         self.out.branch("%s_mass_nom" % self.jetBranchName, "F", lenVar=self.lenVar)
         if self.doGroomed:
             self.out.branch("%s_msoftdrop_nom" % self.jetBranchName, "F", lenVar=self.lenVar)
+            self.out.branch("%s_msoftdrop_tau21DDT_nom" % self.jetBranchName, "F", lenVar=self.lenVar)
             
         if self.corrMET:
             self.out.branch("%s_pt_nom" % self.metBranchName, "F")
@@ -160,6 +177,10 @@ class jetmetUncertaintiesProducer(Module):
                 self.out.branch("%s_msoftdrop_jmr%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
                 self.out.branch("%s_msoftdrop_jms%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
 
+                self.out.branch("%s_msoftdrop_tau21DDT_jer%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
+                self.out.branch("%s_msoftdrop_tau21DDT_jmr%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
+                self.out.branch("%s_msoftdrop_tau21DDT_jms%s" % (self.jetBranchName, shift), "F", lenVar=self.lenVar)
+
             if self.corrMET :
                 self.out.branch("%s_pt_jer%s" % (self.metBranchName, shift), "F")
                 self.out.branch("%s_phi_jer%s" % (self.metBranchName, shift), "F")
@@ -168,6 +189,7 @@ class jetmetUncertaintiesProducer(Module):
                 self.out.branch("%s_mass_jes%s%s" % (self.jetBranchName, jesUncertainty, shift), "F", lenVar=self.lenVar)
                 if self.doGroomed:
                     self.out.branch("%s_msoftdrop_jes%s%s" % (self.jetBranchName, jesUncertainty, shift), "F", lenVar=self.lenVar)
+                    self.out.branch("%s_msoftdrop_tau21DDT_jes%s%s" % (self.jetBranchName, jesUncertainty, shift), "F", lenVar=self.lenVar)
                 if self.corrMET :
                     self.out.branch("%s_pt_jes%s%s" % (self.metBranchName, jesUncertainty, shift), "F")
                     self.out.branch("%s_phi_jes%s%s" % (self.metBranchName, jesUncertainty, shift), "F")
@@ -235,9 +257,23 @@ class jetmetUncertaintiesProducer(Module):
             jets_msdcorr_jesDown = {}
             jets_msdcorr_jmsUp   = []
             jets_msdcorr_jmsDown = []
+            #Additional jms and jmr corrections in tau21DDT region. See
+            #https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#tau21DDT_0_43
+            jets_msdcorr_tau21DDT_nom     = []
+            jets_msdcorr_tau21DDT_jerUp   = []
+            jets_msdcorr_tau21DDT_jerDown = []
+            jets_msdcorr_tau21DDT_jmrUp   = []
+            jets_msdcorr_tau21DDT_jmrDown = []
+            jets_msdcorr_tau21DDT_jesUp   = {}
+            jets_msdcorr_tau21DDT_jesDown = {}
+            jets_msdcorr_tau21DDT_jmsUp   = []
+            jets_msdcorr_tau21DDT_jmsDown = []
             for jesUncertainty in self.jesUncertainties:
                 jets_msdcorr_jesUp[jesUncertainty]   = []
                 jets_msdcorr_jesDown[jesUncertainty] = []
+                #tau21DDT
+                jets_msdcorr_tau21DDT_jesUp[jesUncertainty]   = []
+                jets_msdcorr_tau21DDT_jesDown[jesUncertainty] = []
 
                 
         rho = getattr(event, self.rhoBranchName)
@@ -306,21 +342,18 @@ class jetmetUncertaintiesProducer(Module):
 
 
             if self.doGroomed :
-                # to evaluate JES uncertainties
-                jet_msdcorr_jmsUp   = []
-                jet_msdcorr_jmsDown = []
-                jet_msdcorr_jesUp   = {}
-                jet_msdcorr_jesDown = {}
 
                 #msoftdrop scale systematics
                 jmsNomVal = self.jmsSDVals[0]
                 jmsDownVal = self.jmsSDVals[1]
                 jmsUpVal = self.jmsSDVals[2]
+
                 
-                ( jet_msdcorr_jmrNomVal, jet_msdcorr_jmrUpVal, jet_msdcorr_jmrDownVal ) = self.jetSmearer.getSmearValsM(groomedP4, genGroomedJet) if groomedP4 != None and genGroomedJet != None else (0.,0.,0.)
+                ( jet_msdcorr_jmrNomVal, jet_msdcorr_jmrUpVal, jet_msdcorr_jmrDownVal) = self.jetSmearer.getSmearValsM(groomedP4, genGroomedJet, self.jmrSDVals) if groomedP4 != None and genGroomedJet != None else (0.,0.,0.)
                 jet_msdcorr_raw = groomedP4.M() if groomedP4 != None else 0.0
                 if jet_msdcorr_raw < 0.0:
                     jet_msdcorr_raw *= -1.0
+
                 jet_msdcorr_nom           = jet_pt_jerNomVal*jet_msdcorr_jmrNomVal*jet_msdcorr_raw
                 jets_msdcorr_nom    .append(jet_msdcorr_nom)
                 jets_msdcorr_jerUp  .append(jet_pt_jerUpVal  *jet_msdcorr_jmrNomVal *jmsNomVal  *jet_msdcorr_raw)
@@ -330,9 +363,32 @@ class jetmetUncertaintiesProducer(Module):
                 jets_msdcorr_jmsUp  .append(jet_pt_jerNomVal *jet_msdcorr_jmrNomVal *jmsUpVal   *jet_msdcorr_raw)
                 jets_msdcorr_jmsDown.append(jet_pt_jerNomVal *jet_msdcorr_jmrNomVal *jmsDownVal *jet_msdcorr_raw)
 
+                #
+                # for tau21_DDT < 0.43 
+                #
+
+                #msoftdrop scale systematics
+                jmsNomVal = self.jmsSDVals_tau21DDT[0]
+                jmsDownVal = self.jmsSDVals_tau21DDT[1]
+                jmsUpVal = self.jmsSDVals_tau21DDT[2]
+
+                ( jet_msdcorr_tau21DDT_jmrNomVal, jet_msdcorr_tau21DDT_jmrUpVal, jet_msdcorr_tau21DDT_jmrDownVal) = self.jetSmearer.getSmearValsM(groomedP4, genGroomedJet, self.jmrSDVals_tau21DDT) if groomedP4 != None and genGroomedJet != None else (0.,0.,0.)
+
+                # Uncertainties from tau21 < 0.43
+                jet_msdcorr_tau21DDT_nom           = jet_pt_jerNomVal*jet_msdcorr_tau21DDT_jmrNomVal*jet_msdcorr_raw
+                jets_msdcorr_tau21DDT_nom    .append(jet_msdcorr_tau21DDT_nom)
+                jets_msdcorr_tau21DDT_jerUp  .append(jet_pt_jerUpVal  *jet_msdcorr_tau21DDT_jmrNomVal *jmsNomVal  *jet_msdcorr_raw)
+                jets_msdcorr_tau21DDT_jerDown.append(jet_pt_jerDownVal*jet_msdcorr_tau21DDT_jmrNomVal *jmsNomVal  *jet_msdcorr_raw)
+                jets_msdcorr_tau21DDT_jmrUp  .append(jet_pt_jerNomVal *jet_msdcorr_tau21DDT_jmrUpVal  *jmsNomVal  *jet_msdcorr_raw)
+                jets_msdcorr_tau21DDT_jmrDown.append(jet_pt_jerNomVal *jet_msdcorr_tau21DDT_jmrDownVal*jmsNomVal  *jet_msdcorr_raw)
+                jets_msdcorr_tau21DDT_jmsUp  .append(jet_pt_jerNomVal *jet_msdcorr_tau21DDT_jmrNomVal *jmsUpVal   *jet_msdcorr_raw)
+                jets_msdcorr_tau21DDT_jmsDown.append(jet_pt_jerNomVal *jet_msdcorr_tau21DDT_jmrNomVal *jmsDownVal *jet_msdcorr_raw)
+                
+
             
             for jesUncertainty in self.jesUncertainties:
-                # (cf. https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#JetCorUncertainties )
+                #
+                #(cf. https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#JetCorUncertainties )
                 self.jesUncertainty[jesUncertainty].setJetPt(jet_pt_nom)
                 self.jesUncertainty[jesUncertainty].setJetEta(jet.eta)
                 delta = self.jesUncertainty[jesUncertainty].getUncertainty(True)
@@ -345,10 +401,15 @@ class jetmetUncertaintiesProducer(Module):
                 jets_mass_jesUp  [jesUncertainty].append(jet_mass_jesUp[jesUncertainty])
                 jets_mass_jesDown[jesUncertainty].append(jet_mass_jesDown[jesUncertainty])
                 if self.doGroomed :
-                    jet_msdcorr_jesUp   [jesUncertainty] = jet_msdcorr_nom*(1. + delta)
-                    jet_msdcorr_jesDown [jesUncertainty] = jet_msdcorr_nom*(1. - delta)
-                    jets_msdcorr_jesUp  [jesUncertainty].append(jet_msdcorr_jesUp[jesUncertainty])
-                    jets_msdcorr_jesDown[jesUncertainty].append(jet_msdcorr_jesDown[jesUncertainty])                    
+                    jet_msdcorr_jesUp = jet_msdcorr_tau21DDT_nom*(1. + delta)
+                    jet_msdcorr_jesDown = jet_msdcorr_tau21DDT_nom*(1. - delta)
+                    jets_msdcorr_jesUp  [jesUncertainty].append(jet_msdcorr_jesUp)
+                    jets_msdcorr_jesDown[jesUncertainty].append(jet_msdcorr_jesDown)                    
+                    ## Uncertainties from tau21 < 0.43
+                    jet_msdcorr_tau21DDT_jesUp = jet_msdcorr_nom*(1. + delta)
+                    jet_msdcorr_tau21DDT_jesDown = jet_msdcorr_nom*(1. - delta)
+                    jets_msdcorr_tau21DDT_jesUp  [jesUncertainty].append(jet_msdcorr_tau21DDT_jesUp)
+                    jets_msdcorr_tau21DDT_jesDown[jesUncertainty].append(jet_msdcorr_tau21DDT_jesDown)                    
 
             # progate JER and JES corrections and uncertainties to MET
             if self.corrMET and jet_pt_nom > self.unclEnThreshold:
@@ -417,6 +478,16 @@ class jetmetUncertaintiesProducer(Module):
             self.out.fillBranch("%s_msoftdrop_jmrDown" % self.jetBranchName, jets_msdcorr_jmrDown)
             self.out.fillBranch("%s_msoftdrop_jmsUp" % self.jetBranchName, jets_msdcorr_jmsUp)
             self.out.fillBranch("%s_msoftdrop_jmsDown" % self.jetBranchName, jets_msdcorr_jmsDown)
+            
+            #tau21DDT < 0.43
+
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_nom" % self.jetBranchName, jets_msdcorr_nom)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jerUp" % self.jetBranchName, jets_msdcorr_jerUp)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jerDown" % self.jetBranchName, jets_msdcorr_jerDown)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jmrUp" % self.jetBranchName, jets_msdcorr_jmrUp)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jmrDown" % self.jetBranchName, jets_msdcorr_jmrDown)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jmsUp" % self.jetBranchName, jets_msdcorr_jmsUp)
+            self.out.fillBranch("%s_msoftdrop_tau21DDT_jmsDown" % self.jetBranchName, jets_msdcorr_jmsDown)
 
             
         if self.corrMET :
@@ -436,8 +507,8 @@ class jetmetUncertaintiesProducer(Module):
             if self.doGroomed : 
                 self.out.fillBranch("%s_msoftdrop_jes%sUp" % (self.jetBranchName, jesUncertainty), jets_msdcorr_jesUp[jesUncertainty])
                 self.out.fillBranch("%s_msoftdrop_jes%sDown" % (self.jetBranchName, jesUncertainty), jets_msdcorr_jesDown[jesUncertainty])
-                
-            
+                self.out.fillBranch("%s_msoftdrop_tau21DDT_jes%sUp" % (self.jetBranchName, jesUncertainty), jets_msdcorr_tau21DDT_jesUp[jesUncertainty])
+                self.out.fillBranch("%s_msoftdrop_tau21DDT_jes%sDown" % (self.jetBranchName, jesUncertainty), jets_msdcorr_tau21DDT_jesDown[jesUncertainty])
             if self.corrMET:
                 self.out.fillBranch("%s_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_px_jesUp[jesUncertainty]**2 + met_py_jesUp[jesUncertainty]**2))
                 self.out.fillBranch("%s_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_py_jesUp[jesUncertainty], met_px_jesUp[jesUncertainty]))

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -50,6 +50,15 @@ class jetmetUncertaintiesProducer(Module):
         self.lenVar = "n" + self.jetBranchName
         # To do : change to real values
         self.jmsVals = [1.00, 0.99, 1.01]
+        # Scale for m_softdrop
+        self.jmsSDVals = [1.00, 1.00, 1.00]
+        if era == '2016':
+            self.jmsSDVals = [1.00, 0.9906, 1.0094]
+            #self.jmrSDVals = [1.00, 0.8 , 1.2]
+        else:
+        # To do : change to real values
+            self.jmsSDVals = [1.00, 0.99, 1.01]
+            #self.jmrSDVals = [0.1, 0.2, 0.0]
         
 
         # read jet energy scale (JES) uncertainties
@@ -277,6 +286,11 @@ class jetmetUncertaintiesProducer(Module):
                 jet_msdcorr_jmsDown = []
                 jet_msdcorr_jesUp   = {}
                 jet_msdcorr_jesDown = {}
+
+                #msoftdrop scale systematics
+                jmsNomVal = self.jmsSDVals[0]
+                jmsDownVal = self.jmsSDVals[1]
+                jmsUpVal = self.jmsSDVals[2]
                 
                 ( jet_msdcorr_jmrNomVal, jet_msdcorr_jmrUpVal, jet_msdcorr_jmrDownVal ) = self.jetSmearer.getSmearValsM(groomedP4, genGroomedJet) if groomedP4 != None and genGroomedJet != None else (0.,0.,0.)
                 jet_msdcorr_raw = groomedP4.M() if groomedP4 != None else 0.0
@@ -425,6 +439,7 @@ jetmetUncertainties2017AK4PuppiAll = lambda : jetmetUncertaintiesProducer("2017"
 jetmetUncertainties2016AK8Puppi = lambda : jetmetUncertaintiesProducer("2016", "Summer16_23Sep2016V4_MC", [ "Total" ], jetType="AK8PFPuppi")
 jetmetUncertainties2016AK8PuppiAll = lambda : jetmetUncertaintiesProducer("2016", "Summer16_23Sep2016V4_MC",  [ "All" ], jetType="AK8PFPuppi")
 jetmetUncertainties2016AK8PuppiNoGroom = lambda : jetmetUncertaintiesProducer("2016", "Summer16_23Sep2016V4_MC", [ "Total" ], jetType="AK8PFPuppi",redoJEC=False,noGroom=True)
+jetmetUncertainties2016AK8PuppiTotal = lambda: jetmetUncertaintiesProducer("2016", "Summer16_23Sep2016V4_MC", [ "Total" ],jetType="AK8PFPuppi",redoJEC=False,noGroom=False)
 jetmetUncertainties2016AK8PuppiAllNoGroom = lambda : jetmetUncertaintiesProducer("2016", "Summer16_23Sep2016V4_MC", ["All"], jetType="AK8PFPuppi",redoJEC=False,noGroom=True)
 jetmetUncertainties2017AK8Puppi = lambda : jetmetUncertaintiesProducer("2017", "Fall17_17Nov2017_V6_MC", [ "Total" ], jetType="AK8PFPuppi")
 jetmetUncertainties2017AK8PuppiAll = lambda : jetmetUncertaintiesProducer("2017", "Fall17_17Nov2017_V6_MC", ["All"], jetType="AK8PFPuppi")

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -401,13 +401,13 @@ class jetmetUncertaintiesProducer(Module):
                 jets_mass_jesUp  [jesUncertainty].append(jet_mass_jesUp[jesUncertainty])
                 jets_mass_jesDown[jesUncertainty].append(jet_mass_jesDown[jesUncertainty])
                 if self.doGroomed :
-                    jet_msdcorr_jesUp = jet_msdcorr_tau21DDT_nom*(1. + delta)
-                    jet_msdcorr_jesDown = jet_msdcorr_tau21DDT_nom*(1. - delta)
+                    jet_msdcorr_jesUp = jet_msdcorr_nom*(1. + delta)
+                    jet_msdcorr_jesDown = jet_msdcorr_nom*(1. - delta)
                     jets_msdcorr_jesUp  [jesUncertainty].append(jet_msdcorr_jesUp)
                     jets_msdcorr_jesDown[jesUncertainty].append(jet_msdcorr_jesDown)                    
                     ## Uncertainties from tau21 < 0.43
-                    jet_msdcorr_tau21DDT_jesUp = jet_msdcorr_nom*(1. + delta)
-                    jet_msdcorr_tau21DDT_jesDown = jet_msdcorr_nom*(1. - delta)
+                    jet_msdcorr_tau21DDT_jesUp = jet_msdcorr_tau21DDT_nom*(1. + delta)
+                    jet_msdcorr_tau21DDT_jesDown = jet_msdcorr_tau21DDT_nom*(1. - delta)
                     jets_msdcorr_tau21DDT_jesUp  [jesUncertainty].append(jet_msdcorr_tau21DDT_jesUp)
                     jets_msdcorr_tau21DDT_jesDown[jesUncertainty].append(jet_msdcorr_tau21DDT_jesDown)                    
 

--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -189,7 +189,6 @@ class jetmetUncertaintiesProducer(Module):
                 self.out.branch("%s_mass_jes%s%s" % (self.jetBranchName, jesUncertainty, shift), "F", lenVar=self.lenVar)
                 if self.doGroomed:
                     self.out.branch("%s_msoftdrop_jes%s%s" % (self.jetBranchName, jesUncertainty, shift), "F", lenVar=self.lenVar)
-                    self.out.branch("%s_msoftdrop_tau21DDT_jes%s%s" % (self.jetBranchName, jesUncertainty, shift), "F", lenVar=self.lenVar)
                 if self.corrMET :
                     self.out.branch("%s_pt_jes%s%s" % (self.metBranchName, jesUncertainty, shift), "F")
                     self.out.branch("%s_phi_jes%s%s" % (self.metBranchName, jesUncertainty, shift), "F")
@@ -264,16 +263,11 @@ class jetmetUncertaintiesProducer(Module):
             jets_msdcorr_tau21DDT_jerDown = []
             jets_msdcorr_tau21DDT_jmrUp   = []
             jets_msdcorr_tau21DDT_jmrDown = []
-            jets_msdcorr_tau21DDT_jesUp   = {}
-            jets_msdcorr_tau21DDT_jesDown = {}
             jets_msdcorr_tau21DDT_jmsUp   = []
             jets_msdcorr_tau21DDT_jmsDown = []
             for jesUncertainty in self.jesUncertainties:
                 jets_msdcorr_jesUp[jesUncertainty]   = []
                 jets_msdcorr_jesDown[jesUncertainty] = []
-                #tau21DDT
-                jets_msdcorr_tau21DDT_jesUp[jesUncertainty]   = []
-                jets_msdcorr_tau21DDT_jesDown[jesUncertainty] = []
 
                 
         rho = getattr(event, self.rhoBranchName)
@@ -401,15 +395,10 @@ class jetmetUncertaintiesProducer(Module):
                 jets_mass_jesUp  [jesUncertainty].append(jet_mass_jesUp[jesUncertainty])
                 jets_mass_jesDown[jesUncertainty].append(jet_mass_jesDown[jesUncertainty])
                 if self.doGroomed :
-                    jet_msdcorr_jesUp = jet_msdcorr_nom*(1. + delta)
-                    jet_msdcorr_jesDown = jet_msdcorr_nom*(1. - delta)
+                    jet_msdcorr_jesUp = (1. + delta)
+                    jet_msdcorr_jesDown = (1. - delta)
                     jets_msdcorr_jesUp  [jesUncertainty].append(jet_msdcorr_jesUp)
                     jets_msdcorr_jesDown[jesUncertainty].append(jet_msdcorr_jesDown)                    
-                    ## Uncertainties from tau21 < 0.43
-                    jet_msdcorr_tau21DDT_jesUp = jet_msdcorr_tau21DDT_nom*(1. + delta)
-                    jet_msdcorr_tau21DDT_jesDown = jet_msdcorr_tau21DDT_nom*(1. - delta)
-                    jets_msdcorr_tau21DDT_jesUp  [jesUncertainty].append(jet_msdcorr_tau21DDT_jesUp)
-                    jets_msdcorr_tau21DDT_jesDown[jesUncertainty].append(jet_msdcorr_tau21DDT_jesDown)                    
 
             # progate JER and JES corrections and uncertainties to MET
             if self.corrMET and jet_pt_nom > self.unclEnThreshold:
@@ -507,8 +496,6 @@ class jetmetUncertaintiesProducer(Module):
             if self.doGroomed : 
                 self.out.fillBranch("%s_msoftdrop_jes%sUp" % (self.jetBranchName, jesUncertainty), jets_msdcorr_jesUp[jesUncertainty])
                 self.out.fillBranch("%s_msoftdrop_jes%sDown" % (self.jetBranchName, jesUncertainty), jets_msdcorr_jesDown[jesUncertainty])
-                self.out.fillBranch("%s_msoftdrop_tau21DDT_jes%sUp" % (self.jetBranchName, jesUncertainty), jets_msdcorr_tau21DDT_jesUp[jesUncertainty])
-                self.out.fillBranch("%s_msoftdrop_tau21DDT_jes%sDown" % (self.jetBranchName, jesUncertainty), jets_msdcorr_tau21DDT_jesDown[jesUncertainty])
             if self.corrMET:
                 self.out.fillBranch("%s_pt_jes%sUp" % (self.metBranchName, jesUncertainty), math.sqrt(met_px_jesUp[jesUncertainty]**2 + met_py_jesUp[jesUncertainty]**2))
                 self.out.fillBranch("%s_phi_jes%sUp" % (self.metBranchName, jesUncertainty), math.atan2(met_py_jesUp[jesUncertainty], met_px_jesUp[jesUncertainty]))


### PR DESCRIPTION
For FatJet Puppi msoftdrop:
- Add jmr with gen matching for 2016 dataset. Update the systematics for jmr and jms.
- Update the jes, jmr and jms scale numbers for 2016 and 2017 in case of tau21DDT < 0.43 (corresponding branches have _DDT).
Numbers taken from 
https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetWtagging#tau21DDT_0_43
